### PR TITLE
Improved reading of default Cache settings

### DIFF
--- a/Lib/Sensor.php
+++ b/Lib/Sensor.php
@@ -62,7 +62,7 @@ abstract class Sensor {
 		}
 
 		$settings = array_merge(
-			\Configure::read('Cache.default'),
+			\Cache::settings(),
 			array('duration' => $duration)
 		);
 


### PR DESCRIPTION
Since it is not default behaviour to save cache settings in the configuration, we should read the settings directly from the cache instead of from the configuration to ensure compatibility with other project setups.