### PR TITLE
Remove Migrations plugin loading

### DIFF
--- a/src/Heartbeat/Sensor/DBUpToDate.php
+++ b/src/Heartbeat/Sensor/DBUpToDate.php
@@ -2,7 +2,6 @@
 
 namespace OrcaServices\Heartbeat\Heartbeat\Sensor;
 
-use Cake\Core\Plugin;
 use Migrations\Migrations;
 use OrcaServices\Heartbeat\Heartbeat\Sensor;
 
@@ -25,10 +24,6 @@ class DBUpToDate extends Sensor
      */
     protected function _getStatus()
     {
-        if (!Plugin::loaded('Migrations')) {
-            Plugin::load('Migrations');
-        }
-
         $dbMigrated = true;
         try {
             $migrations = new Migrations();


### PR DESCRIPTION
Closes #18 

As the related PR https://github.com/cakephp/migrations/pull/384 was merged, we should be able to use the migrations class without loading the plugin, once a new version, e.g. 2.1.1, of the CakePHP Migrations plugin is released.

https://github.com/cakephp/migrations/compare/2.1.0...master