### PR TITLE
Sensor status now indicates whether the result were fetched from cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added documentation on how to write a sensor
 - Added documentation about built-in sensors
+- Added cache indicator to sensor status #7
 
 ### Changed
 
@@ -32,6 +33,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fixed DB Connection Sensor
+- Always reset cache config
 
 ## [2.0.0](https://github.com/orca-services/cakephp-heartbeat/releases/tag/2.0.0) - 2018-10-01
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See [CHANGELOG.md](CHANGELOG.md)
 - Support for separate status text
 - Add flexible routing
 - CI integrations
+- Update screenshots in [How to Use](docs/Usage.md) with new cache indicator
 - See [the issues](https://github.com/orca-services/cakephp-heartbeat/issues)
 
 ## License

--- a/src/Heartbeat/Sensor.php
+++ b/src/Heartbeat/Sensor.php
@@ -86,10 +86,15 @@ abstract class Sensor
             return false;
         }
 
-        $cachedStatus = Cache::remember($cacheKey, function () {
-            return $this->_getNonCachedStatus();
-        }, 'heartbeat');
+        $cachedStatus = Cache::read($cacheKey, 'heartbeat');
 
+        if($cachedStatus === false) {
+            $nonCachedStatus = $this->_getNonCachedStatus();
+            Cache::write($cacheKey, $nonCachedStatus, 'heartbeat');
+            return $nonCachedStatus;
+        }
+
+        $cachedStatus->setCheckWasCached(true);
         return $cachedStatus;
     }
 

--- a/src/Heartbeat/Sensor.php
+++ b/src/Heartbeat/Sensor.php
@@ -21,6 +21,11 @@ abstract class Sensor
     const CACHE_NAME = 'heartbeat';
 
     /**
+     * Default cache duration
+     */
+    const CACHE_DEFAULT_DURATION = '+30 seconds';
+
+    /**
      * The sensor config
      *
      * @var Config
@@ -100,7 +105,7 @@ abstract class Sensor
     {
         Cache::drop(self::CACHE_NAME);
 
-        $duration = '+30 seconds';
+        $duration = self::CACHE_DEFAULT_DURATION;
         if (is_string($sensorCaching)) {
             $duration = $sensorCaching;
         }

--- a/src/Heartbeat/Sensor.php
+++ b/src/Heartbeat/Sensor.php
@@ -88,14 +88,16 @@ abstract class Sensor
 
         $cachedStatus = Cache::read($cacheKey, 'heartbeat');
 
-        if($cachedStatus === false) {
-            $nonCachedStatus = $this->_getNonCachedStatus();
-            Cache::write($cacheKey, $nonCachedStatus, 'heartbeat');
-            return $nonCachedStatus;
+        if($cachedStatus !== false) {
+            $cachedStatus->setCheckWasCached(true);
+
+            return $cachedStatus;
         }
 
-        $cachedStatus->setCheckWasCached(true);
-        return $cachedStatus;
+        $nonCachedStatus = $this->_getNonCachedStatus();
+        Cache::write($cacheKey, $nonCachedStatus, 'heartbeat');
+
+        return $nonCachedStatus;
     }
 
     /**

--- a/src/Heartbeat/Sensor.php
+++ b/src/Heartbeat/Sensor.php
@@ -62,6 +62,8 @@ abstract class Sensor
         $cacheKey = 'heartbeat_' . strtolower(Text::slug($this->config->getName()));
         $cached = $this->config->getCached();
 
+        Cache::drop('heartbeat');
+
         $duration = '+30 seconds';
         if (is_string($cached)) {
             $duration = $cached;
@@ -72,10 +74,7 @@ abstract class Sensor
             ['duration' => $duration, 'className' => 'File']
         );
 
-        $heartbeatConfig = Cache::getConfig('heartbeat');
-        if ($heartbeatConfig === null) {
-            Cache::setConfig('heartbeat', $settings);
-        }
+        Cache::setConfig('heartbeat', $settings);
 
         if ($cached === false) {
             $cached = Cache::read($cacheKey, 'heartbeat');

--- a/src/Heartbeat/Sensor.php
+++ b/src/Heartbeat/Sensor.php
@@ -15,6 +15,10 @@ use OrcaServices\Heartbeat\Heartbeat\Sensor\Status;
  */
 abstract class Sensor
 {
+    /**
+     * Cache name used throughout the plugin
+     */
+    const CACHE_NAME = 'heartbeat';
 
     /**
      * The sensor config
@@ -63,17 +67,17 @@ abstract class Sensor
 
         $this->_resetCacheConfig($sensorCaching);
 
-        $cacheKey = 'heartbeat_' . strtolower(Text::slug($this->config->getName()));
+        $cacheKey =  self::CACHE_NAME . '_' . strtolower(Text::slug($this->config->getName()));
         if ($sensorCaching === false) {
-            $cachedStatus = Cache::read($cacheKey, 'heartbeat');
+            $cachedStatus = Cache::read($cacheKey, self::CACHE_NAME);
             if (!empty($cachedStatus)) {
-                Cache::delete($cacheKey, 'heartbeat');
+                Cache::delete($cacheKey, self::CACHE_NAME);
             }
 
             return false;
         }
 
-        $cachedStatus = Cache::read($cacheKey, 'heartbeat');
+        $cachedStatus = Cache::read($cacheKey, self::CACHE_NAME);
         if($cachedStatus !== false) {
             $cachedStatus->setCheckWasCached(true);
 
@@ -81,7 +85,7 @@ abstract class Sensor
         }
 
         $nonCachedStatus = $this->_getNonCachedStatus();
-        Cache::write($cacheKey, $nonCachedStatus, 'heartbeat');
+        Cache::write($cacheKey, $nonCachedStatus, self::CACHE_NAME);
 
         return $nonCachedStatus;
     }
@@ -94,7 +98,7 @@ abstract class Sensor
      */
     protected function _resetCacheConfig($sensorCaching)
     {
-        Cache::drop('heartbeat');
+        Cache::drop(self::CACHE_NAME);
 
         $duration = '+30 seconds';
         if (is_string($sensorCaching)) {
@@ -106,7 +110,7 @@ abstract class Sensor
             ['duration' => $duration, 'className' => 'File']
         );
 
-        Cache::setConfig('heartbeat', $settings);
+        Cache::setConfig(self::CACHE_NAME, $settings);
     }
 
     /**

--- a/src/Heartbeat/Sensor.php
+++ b/src/Heartbeat/Sensor.php
@@ -59,26 +59,14 @@ abstract class Sensor
      */
     protected function _getCachedStatus()
     {
+        $sensorCaching = $this->config->getCached();
+
+        $this->_resetCacheConfig($sensorCaching);
+
         $cacheKey = 'heartbeat_' . strtolower(Text::slug($this->config->getName()));
-        $cached = $this->config->getCached();
-
-        Cache::drop('heartbeat');
-
-        $duration = '+30 seconds';
-        if (is_string($cached)) {
-            $duration = $cached;
-        }
-
-        $settings = array_merge(
-            (array)Cache::getConfig('default'),
-            ['duration' => $duration, 'className' => 'File']
-        );
-
-        Cache::setConfig('heartbeat', $settings);
-
-        if ($cached === false) {
-            $cached = Cache::read($cacheKey, 'heartbeat');
-            if (!empty($cached)) {
+        if ($sensorCaching === false) {
+            $cachedStatus = Cache::read($cacheKey, 'heartbeat');
+            if (!empty($cachedStatus)) {
                 Cache::delete($cacheKey, 'heartbeat');
             }
 
@@ -86,7 +74,6 @@ abstract class Sensor
         }
 
         $cachedStatus = Cache::read($cacheKey, 'heartbeat');
-
         if($cachedStatus !== false) {
             $cachedStatus->setCheckWasCached(true);
 
@@ -97,6 +84,29 @@ abstract class Sensor
         Cache::write($cacheKey, $nonCachedStatus, 'heartbeat');
 
         return $nonCachedStatus;
+    }
+
+    /**
+     * Reset the cache configuration
+     *
+     * @param bool|string $sensorCaching The sensor cache configuration, either a bool or a relative time string.
+     * @return void
+     */
+    protected function _resetCacheConfig($sensorCaching)
+    {
+        Cache::drop('heartbeat');
+
+        $duration = '+30 seconds';
+        if (is_string($sensorCaching)) {
+            $duration = $sensorCaching;
+        }
+
+        $settings = array_merge(
+            (array)Cache::getConfig('default'),
+            ['duration' => $duration, 'className' => 'File']
+        );
+
+        Cache::setConfig('heartbeat', $settings);
     }
 
     /**

--- a/src/Heartbeat/Sensor/Status.php
+++ b/src/Heartbeat/Sensor/Status.php
@@ -140,7 +140,7 @@ class Status
      *
      * @param bool $wasCached
      */
-    public function setCheckWasCached(bool $wasCached): void {
+    public function setCheckWasCached(bool $wasCached) {
 
         $this->checkCached = $wasCached;
     }

--- a/src/Heartbeat/Sensor/Status.php
+++ b/src/Heartbeat/Sensor/Status.php
@@ -61,6 +61,13 @@ class Status
     protected $severity;
 
     /**
+     * Whether sensor status was fetched from cache
+     *
+     * @var bool
+     */
+    protected $checkCached = false;
+
+    /**
      * Status construction
      *
      * @param string $name The name of the sensor
@@ -126,5 +133,25 @@ class Status
     public function getSeverity()
     {
         return $this->severity;
+    }
+
+    /**
+     * Set whether the sensor status was fetched from cache
+     *
+     * @param bool $wasCached
+     */
+    public function setCheckWasCached(bool $wasCached): void {
+
+        $this->checkCached = $wasCached;
+    }
+
+    /**
+     * Check whether sensor status was fetched from cache
+     *
+     * @return bool Whether status was cached
+     */
+    public function wasCheckCached(): bool
+    {
+        return $this->checkCached;
     }
 }

--- a/src/Template/Element/status_table.ctp
+++ b/src/Template/Element/status_table.ctp
@@ -18,6 +18,7 @@ $sensorStatuses->some(function ($sensorStatus) {
     $severity = $sensorStatus->getSeverity();
     $duration = $sensorStatus->getDuration();
     $lastExecuted = $sensorStatus->getLastExecuted();
+    $wasCheckFromCache = $sensorStatus->wasCheckCached();
 
     if ($status === true) {
         $statusText = 'OK';
@@ -57,6 +58,10 @@ $sensorStatuses->some(function ($sensorStatus) {
             [
                 $lastExecuted,
                 ['class' => $tableClass],
+            ],
+            [
+                $wasCheckFromCache ? 'Cached' : 'Not cached',
+                ['class' => $wasCheckFromCache ? 'primary' : 'secondary']
             ],
         ],
     ]);

--- a/src/Template/Element/status_table.ctp
+++ b/src/Template/Element/status_table.ctp
@@ -60,8 +60,7 @@ $sensorStatuses->some(function ($sensorStatus) {
                 ['class' => $tableClass],
             ],
             [
-                $wasCheckFromCache ? 'Cached' : 'Not cached',
-                ['class' => $wasCheckFromCache ? 'success' : 'info']
+                $wasCheckFromCache ? 'Cached' : 'Not cached'
             ],
         ],
     ]);

--- a/src/Template/Element/status_table.ctp
+++ b/src/Template/Element/status_table.ctp
@@ -61,7 +61,7 @@ $sensorStatuses->some(function ($sensorStatus) {
             ],
             [
                 $wasCheckFromCache ? 'Cached' : 'Not cached',
-                ['class' => $wasCheckFromCache ? 'primary' : 'secondary']
+                ['class' => $wasCheckFromCache ? 'success' : 'info']
             ],
         ],
     ]);

--- a/src/Template/Heartbeat/json/index.ctp
+++ b/src/Template/Heartbeat/json/index.ctp
@@ -19,6 +19,7 @@ $statuses = $sensorStatuses->map(function ($sensorStatus) {
     $severity = $sensorStatus->getSeverity();
     $duration = $sensorStatus->getDuration();
     $lastExecuted = $sensorStatus->getLastExecuted()->format('Y-m-d H:i:s');
+    $wasCheckFromCache = $sensorStatus->wasCheckCached();
 
     if ($status === true) {
         $statusText = 'OK';
@@ -28,7 +29,7 @@ $statuses = $sensorStatuses->map(function ($sensorStatus) {
         $statusText = $status;
     }
 
-    return compact('name', 'status', 'statusText', 'severity', 'duration', 'lastExecuted');
+    return compact('name', 'status', 'statusText', 'severity', 'duration', 'lastExecuted', 'wasCheckFromCache');
 });
 
 $heartbeat = [

--- a/tests/TestCase/Heartbeat/Sensor/ConfigTest.php
+++ b/tests/TestCase/Heartbeat/Sensor/ConfigTest.php
@@ -6,6 +6,11 @@ use OrcaServices\Heartbeat\Heartbeat\Sensor\Config;
 use OrcaServices\Heartbeat\Test\TestCase\Heartbeat\DummySensor;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Config Tests
+ *
+ * @coversDefaultClass \OrcaServices\Heartbeat\Heartbeat\Sensor\Config
+ */
 class ConfigTest extends TestCase
 {
     /**

--- a/tests/TestCase/Heartbeat/Sensor/StatusTest.php
+++ b/tests/TestCase/Heartbeat/Sensor/StatusTest.php
@@ -8,6 +8,11 @@ use OrcaServices\Heartbeat\Heartbeat\Sensor\Status;
 use OrcaServices\Heartbeat\Test\TestCase\Heartbeat\DummySensor;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Status Tests
+ *
+ * @coversDefaultClass \OrcaServices\Heartbeat\Heartbeat\Sensor\Status
+ */
 class StatusTest extends TestCase
 {
     /**

--- a/tests/TestCase/Heartbeat/Sensor/StatusTest.php
+++ b/tests/TestCase/Heartbeat/Sensor/StatusTest.php
@@ -3,9 +3,7 @@
 namespace OrcaServices\Heartbeat\Test\TestCase\Heartbeat\Sensor;
 
 use Cake\Chronos\Chronos;
-use OrcaServices\Heartbeat\Heartbeat\Sensor\Config;
 use OrcaServices\Heartbeat\Heartbeat\Sensor\Status;
-use OrcaServices\Heartbeat\Test\TestCase\Sensor\DummySensor;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -41,35 +39,20 @@ class StatusTest extends TestCase
     }
 
     /**
-     * Tests whether the check result was fetched from cache or by running the check now
+     * Tests setting & getting whether the check was cached
      *
      * @return void
+     * @covers ::setCheckWasCached
      * @covers ::wasCheckCached
      */
-    public function testWasCheckCached()
+    public function testSetGetCheckWasCached()
     {
-        Chronos::setTestNow('2017-03-30 12:45:37');
-        $sensorName = 'Cached Sensor';
-        $sensorConfig = [
-            'enabled' => true,
-            'severity' => 1,
-            'class' => DummySensor::class,
-            'cached' => "+1 seconds"
-        ];
-        $sensorConfig = new Config($sensorName, $sensorConfig);
-        $sensorClassName = $sensorConfig->getClass();
-
-        /** @var DummySensor $sensor */
-        $sensor = new $sensorClassName($sensorConfig);
-        $status = $sensor->getStatus();
-
-        // Assert that result was not cached
+        $status = new Status('Dummy Sensor', true, 0, Chronos::now(), 1);
+        $this->assertFalse($status->wasCheckCached());
+        $status->setCheckWasCached(true);
+        $this->assertTrue($status->wasCheckCached());
+        $status->setCheckWasCached(false);
         $this->assertFalse($status->wasCheckCached());
 
-        // Get status again and assert that result was cached
-        /** @var DummySensor $sensor */
-        $sensor = new $sensorClassName($sensorConfig);
-        $status = $sensor->getStatus();
-        $this->assertTrue($status->wasCheckCached());
     }
 }

--- a/tests/TestCase/Heartbeat/Sensor/StatusTest.php
+++ b/tests/TestCase/Heartbeat/Sensor/StatusTest.php
@@ -25,6 +25,7 @@ class StatusTest extends TestCase
      * @covers ::getDuration
      * @covers ::getLastExecuted
      * @covers ::getSeverity
+     * @covers ::wasCheckCached
      */
     public function testStatus()
     {
@@ -36,6 +37,7 @@ class StatusTest extends TestCase
         $this->assertEquals(0, $status->getDuration());
         $this->assertEquals('2017-03-30 12:45:37', $status->getLastExecuted());
         $this->assertEquals(1, $status->getSeverity());
+        $this->assertEquals(false, $status->wasCheckCached());
     }
 
     /**

--- a/tests/TestCase/Heartbeat/Sensor/StatusTest.php
+++ b/tests/TestCase/Heartbeat/Sensor/StatusTest.php
@@ -5,7 +5,7 @@ namespace OrcaServices\Heartbeat\Test\TestCase\Heartbeat\Sensor;
 use Cake\Chronos\Chronos;
 use OrcaServices\Heartbeat\Heartbeat\Sensor\Config;
 use OrcaServices\Heartbeat\Heartbeat\Sensor\Status;
-use OrcaServices\Heartbeat\Test\TestCase\Heartbeat\DummySensor;
+use OrcaServices\Heartbeat\Test\TestCase\Sensor\DummySensor;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/TestCase/Heartbeat/Sensor/StatusTest.php
+++ b/tests/TestCase/Heartbeat/Sensor/StatusTest.php
@@ -3,7 +3,9 @@
 namespace OrcaServices\Heartbeat\Test\TestCase\Heartbeat\Sensor;
 
 use Cake\Chronos\Chronos;
+use OrcaServices\Heartbeat\Heartbeat\Sensor\Config;
 use OrcaServices\Heartbeat\Heartbeat\Sensor\Status;
+use OrcaServices\Heartbeat\Test\TestCase\Heartbeat\DummySensor;
 use PHPUnit\Framework\TestCase;
 
 class StatusTest extends TestCase
@@ -29,5 +31,38 @@ class StatusTest extends TestCase
         $this->assertEquals(0, $status->getDuration());
         $this->assertEquals('2017-03-30 12:45:37', $status->getLastExecuted());
         $this->assertEquals(1, $status->getSeverity());
+    }
+
+    /**
+     * Tests whether the check result was fetched from cache or by running the check now
+     *
+     * @return void
+     * @covers Status::wasCheckCached
+     */
+    public function testWasCheckCached()
+    {
+        Chronos::setTestNow('2017-03-30 12:45:37');
+        $sensorName = 'Cache Sensor';
+        $sensorConfig = [
+            'enabled' => true,
+            'severity' => 1,
+            'class' => DummySensor::class,
+            'cached' => "+1 seconds"
+        ];
+        $sensorConfig = new Config($sensorName, $sensorConfig);
+        $sensorClassName = $sensorConfig->getClass();
+
+        /** @var DummySensor $sensor */
+        $sensor = new $sensorClassName($sensorConfig);
+        $status = $sensor->getStatus();
+
+        // Assert that result was not cached
+        $this->assertFalse($status->wasCheckCached());
+
+        // Get status again and assert that result was cached
+        /** @var DummySensor $sensor */
+        $sensor = new $sensorClassName($sensorConfig);
+        $status = $sensor->getStatus();
+        $this->assertTrue($status->wasCheckCached());
     }
 }

--- a/tests/TestCase/Heartbeat/Sensor/StatusTest.php
+++ b/tests/TestCase/Heartbeat/Sensor/StatusTest.php
@@ -37,7 +37,7 @@ class StatusTest extends TestCase
      * Tests whether the check result was fetched from cache or by running the check now
      *
      * @return void
-     * @covers Status::wasCheckCached
+     * @covers ::wasCheckCached
      */
     public function testWasCheckCached()
     {

--- a/tests/TestCase/Heartbeat/Sensor/StatusTest.php
+++ b/tests/TestCase/Heartbeat/Sensor/StatusTest.php
@@ -42,7 +42,7 @@ class StatusTest extends TestCase
     public function testWasCheckCached()
     {
         Chronos::setTestNow('2017-03-30 12:45:37');
-        $sensorName = 'Cache Sensor';
+        $sensorName = 'Cached Sensor';
         $sensorConfig = [
             'enabled' => true,
             'severity' => 1,

--- a/tests/TestCase/Heartbeat/SensorTest.php
+++ b/tests/TestCase/Heartbeat/SensorTest.php
@@ -6,6 +6,9 @@ use Cake\Chronos\Chronos;
 use Cake\TestSuite\TestCase;
 use OrcaServices\Heartbeat\Heartbeat\Sensor;
 
+/**
+ * A Dummy Sensor for testing purposes
+ */
 class DummySensor extends Sensor
 {
     /**

--- a/tests/TestCase/Heartbeat/SensorTest.php
+++ b/tests/TestCase/Heartbeat/SensorTest.php
@@ -70,6 +70,7 @@ class SensorTest extends TestCase
      *
      * @return void
      * @covers ::_getCachedStatus
+     * @covers ::_resetCacheConfig
      * @covers ::_getNonCachedStatus
      */
     public function testWasCheckCached()
@@ -112,6 +113,7 @@ class SensorTest extends TestCase
      *
      * @return void
      * @covers ::_getCachedStatus
+     * @covers ::_resetCacheConfig
      * @covers ::_getNonCachedStatus
      */
     public function testWasCheckCachedWhenCacheDisabled()

--- a/tests/TestCase/Heartbeat/SensorTest.php
+++ b/tests/TestCase/Heartbeat/SensorTest.php
@@ -5,20 +5,7 @@ namespace OrcaServices\Heartbeat\Test\TestCase\Heartbeat;
 use Cake\Chronos\Chronos;
 use Cake\TestSuite\TestCase;
 use OrcaServices\Heartbeat\Heartbeat\Sensor;
-
-/**
- * A Dummy Sensor for testing purposes
- */
-class DummySensor extends Sensor
-{
-    /**
-     * @inheritDoc
-     */
-    protected function _getStatus()
-    {
-        return true;
-    }
-}
+use OrcaServices\Heartbeat\Test\TestCase\Sensor\DummySensor;
 
 /**
  * Sensor Test

--- a/tests/TestCase/Heartbeat/SensorTest.php
+++ b/tests/TestCase/Heartbeat/SensorTest.php
@@ -73,37 +73,4 @@ class SensorTest extends TestCase
         $this->assertEquals('2017-03-30 12:45:37', $status->getLastExecuted());
         $this->assertEquals(1, $status->getSeverity());
     }
-
-    /**
-     * Tests whether the check result was fetched from cache or by running the check now
-     *
-     * @return void
-     * @covers Sensor\Status::wasCheckCached
-     */
-    public function testWasCheckCached()
-    {
-        Chronos::setTestNow('2017-03-30 12:45:37');
-        $sensorName = 'Dummy Sensor';
-        $sensorConfig = [
-            'enabled' => true,
-            'severity' => 1,
-            'class' => DummySensor::class,
-            'cached' => "+1 seconds"
-        ];
-        $sensorConfig = new Sensor\Config($sensorName, $sensorConfig);
-        $sensorClassName = $sensorConfig->getClass();
-
-        /** @var Sensor $sensor */
-        $sensor = new $sensorClassName($sensorConfig);
-        $status = $sensor->getStatus();
-
-        // Assert that result was not cached
-        $this->assertFalse($status->wasCheckCached());
-
-        // Get status again and assert that result was cached
-        /** @var Sensor $sensor */
-        $sensor = new $sensorClassName($sensorConfig);
-        $status = $sensor->getStatus();
-        $this->assertTrue($status->wasCheckCached());
-    }
 }

--- a/tests/TestCase/Heartbeat/SensorTest.php
+++ b/tests/TestCase/Heartbeat/SensorTest.php
@@ -5,6 +5,7 @@ namespace OrcaServices\Heartbeat\Test\TestCase\Heartbeat;
 use Cake\Chronos\Chronos;
 use Cake\TestSuite\TestCase;
 use OrcaServices\Heartbeat\Heartbeat\Sensor;
+use OrcaServices\Heartbeat\Heartbeat\Sensor\Config;
 use OrcaServices\Heartbeat\Test\TestCase\Sensor\DummySensor;
 
 /**
@@ -28,7 +29,7 @@ class SensorTest extends TestCase
             'severity' => 1,
             'class' => DummySensor::class,
         ];
-        $sensorConfig = new Sensor\Config($sensorName, $sensorConfig);
+        $sensorConfig = new Config($sensorName, $sensorConfig);
         $sensorClassName = $sensorConfig->getClass();
         /** @var Sensor $sensor */
         $sensor = new $sensorClassName($sensorConfig);
@@ -51,7 +52,7 @@ class SensorTest extends TestCase
             'severity' => 1,
             'class' => DummySensor::class,
         ];
-        $sensorConfig = new Sensor\Config($sensorName, $sensorConfig);
+        $sensorConfig = new Config($sensorName, $sensorConfig);
         $sensorClassName = $sensorConfig->getClass();
         /** @var Sensor $sensor */
         $sensor = new $sensorClassName($sensorConfig);
@@ -62,5 +63,34 @@ class SensorTest extends TestCase
         $this->assertEquals(0, $status->getDuration());
         $this->assertEquals('2017-03-30 12:45:37', $status->getLastExecuted());
         $this->assertEquals(1, $status->getSeverity());
+    }
+
+    /**
+     * Tests whether the check result was fetched from cache when cache is disabled
+     *
+     * @return void
+     * @covers ::_getCachedStatus
+     * @covers ::_getNonCachedStatus
+     */
+    public function testWasCheckCachedWhenCacheDisabled()
+    {
+        Chronos::setTestNow('2017-03-30 12:45:37');
+        $sensorName = 'Uncached Sensor';
+        $sensorConfig = [
+            'enabled' => true,
+            'severity' => 1,
+            'class' => DummySensor::class,
+            'cached' => false
+        ];
+        $sensorConfig = new Config($sensorName, $sensorConfig);
+        $sensorClassName = $sensorConfig->getClass();
+
+        /** @var DummySensor $sensor */
+        $sensor = new $sensorClassName($sensorConfig);
+        $status = $sensor->getStatus();
+
+        $this->assertFalse($status->wasCheckCached());
+        $status = $sensor->getStatus();
+        $this->assertFalse($status->wasCheckCached());
     }
 }

--- a/tests/TestCase/Heartbeat/SensorTest.php
+++ b/tests/TestCase/Heartbeat/SensorTest.php
@@ -73,4 +73,37 @@ class SensorTest extends TestCase
         $this->assertEquals('2017-03-30 12:45:37', $status->getLastExecuted());
         $this->assertEquals(1, $status->getSeverity());
     }
+
+    /**
+     * Tests whether the check result was fetched from cache or by running the check now
+     *
+     * @return void
+     * @covers Sensor\Status::wasCheckCached
+     */
+    public function testWasCheckCached()
+    {
+        Chronos::setTestNow('2017-03-30 12:45:37');
+        $sensorName = 'Dummy Sensor';
+        $sensorConfig = [
+            'enabled' => true,
+            'severity' => 1,
+            'class' => DummySensor::class,
+            'cached' => "+1 seconds"
+        ];
+        $sensorConfig = new Sensor\Config($sensorName, $sensorConfig);
+        $sensorClassName = $sensorConfig->getClass();
+
+        /** @var Sensor $sensor */
+        $sensor = new $sensorClassName($sensorConfig);
+        $status = $sensor->getStatus();
+
+        // Assert that result was not cached
+        $this->assertFalse($status->wasCheckCached());
+
+        // Get status again and assert that result was cached
+        /** @var Sensor $sensor */
+        $sensor = new $sensorClassName($sensorConfig);
+        $status = $sensor->getStatus();
+        $this->assertTrue($status->wasCheckCached());
+    }
 }

--- a/tests/TestCase/Sensor/DummySensor.php
+++ b/tests/TestCase/Sensor/DummySensor.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OrcaServices\Heartbeat\Test\TestCase\Sensor;
+
+use OrcaServices\Heartbeat\Heartbeat\Sensor;
+
+/**
+ * A Dummy Sensor for testing purposes
+ */
+class DummySensor extends Sensor
+{
+    /**
+     * @inheritDoc
+     */
+    protected function _getStatus()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
According to feature #7 it was suggested to add the possibility to see whether sensor status was fetched from cache or if it was just run. This adds that feature.