### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,7 @@ chance of keeping on top of things.
 ## Coding Standard
 
 Make sure your code changes comply with the CakePHP Coding standard,
-using [PHP Codesniffer](https://github.com/squizlabs/PHP_CodeSniffer).
+using [PHP Codesniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 Execute the following command from the plugin folder:
 
     vendor/bin/phpcs -p --extensions=php --standard=CakePHP 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932