### PR TITLE
Exclude repository-only files from distribution archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,16 @@
 *.gif binary
 *.ico binary
 *.mo binary
+
+# Exclude repository-only files from distribution archives (git archive / Composer dist).
+# These files are needed for development but not at runtime, keeping the published package lean.
+# https://git-scm.com/docs/gitattributes#_export_ignore
+/.editorconfig      export-ignore
+/.gitattributes     export-ignore
+/.github            export-ignore
+/.gitignore         export-ignore
+/.idea              export-ignore
+/composer.lock      export-ignore
+/phpcs.xml.dist     export-ignore
+/phpunit.xml.dist   export-ignore
+/tests              export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Exclude repository-only files from archives to reduce Composer distribution package size [#37](https://github.com/orca-services/cakephp-heartbeat/issues/37)
 
 ### Dependencies
 Removed unnecessary polyfill Composer dependencies through replace mechanism


### PR DESCRIPTION
Add support for Git’s .gitattributes export-ignore directive to control which files are included when the package is distributed via Composer.

This allows us to exclude repository-only files (e.g. tests, CI configs, docs, tooling) from distribution archives and keep the package leaner.

Closes #37 