### PR TITLE
Make DB connection name for DBUpToDate sensor configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/orca-services/cakephp-heartbeat)
 ### Added
+- Make DB connection name for DBUpToDate sensor configurable [#40](https://github.com/orca-services/cakephp-heartbeat/issues/40)
 
 ### Changed
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -35,6 +35,10 @@ $config['App']['Heartbeat'] = [
             'severity' => 3,
             'class' => OrcaServices\Heartbeat\Heartbeat\Sensor\DBUpToDate::class,
             'cached' => '+10 minutes',
+            'settings' => [
+                'connection_name' => 'default',
+                'source' => 'Migrations',
+            ],
         ],
     ],
 ];

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -38,6 +38,7 @@ $config['App']['Heartbeat'] = [
             'settings' => [
                 'connection_name' => 'default',
                 'source' => 'Migrations',
+                'plugin' => 'MyPlugin',
             ],
         ],
     ],

--- a/docs/Sensors.md
+++ b/docs/Sensors.md
@@ -25,6 +25,31 @@ Uses the Migrations Plugin to check whether all migrations have been run.
 If you use a version of cakephp/migrations below 2.2, you will need to load
 the cakephp/migrations plugin before the sensor is called.
 
+By default, the sensor checks the application's own migrations on the ``default``
+connection. The following settings can be used to point it elsewhere:
+
+- ``connection_name`` The datasource connection to check. Defaults to ``default``.
+- ``source`` The folder the migration files live in. Defaults to ``Migrations``.
+- ``plugin_name`` The plugin that contains the migrations. When omitted, the
+  application's migrations are checked.
+
+To check the migrations of a plugin (e.g. ``MyPlugin``) on a connection other
+than ``default``, e.g. ``external``, the settings can be used like this:
+
+```php
+$config['App']['Heartbeat']['Sensors']['Plugin DB up to date'] = [
+    'enabled' => true,
+    'severity' => 3,
+    'class' => OrcaServices\Heartbeat\Heartbeat\Sensor\DBUpToDate::class,
+    'cached' => '+10 minutes',
+    'settings' => [
+        'connection_name' => 'external',
+        'source' => 'Migrations',
+        'plugin_name' => 'MyPlugin',
+    ],
+];
+```
+
 #### Debug Mode
 Outputs the configuration for the debug mode.
 

--- a/docs/Sensors.md
+++ b/docs/Sensors.md
@@ -30,7 +30,7 @@ connection. The following settings can be used to point it elsewhere:
 
 - ``connection_name`` The datasource connection to check. Defaults to ``default``.
 - ``source`` The folder the migration files live in. Defaults to ``Migrations``.
-- ``plugin_name`` The plugin that contains the migrations. When omitted, the
+- ``plugin`` The plugin that contains the migrations. Defaults to `null`. When omitted, the
   application's migrations are checked.
 
 To check the migrations of a plugin (e.g. ``MyPlugin``) on a connection other
@@ -44,8 +44,8 @@ $config['App']['Heartbeat']['Sensors']['Plugin DB up to date'] = [
     'cached' => '+10 minutes',
     'settings' => [
         'connection_name' => 'external',
-        'source' => 'Migrations',
-        'plugin_name' => 'MyPlugin',
+        'source' => 'MyMigrations',
+        'plugin' => 'MyPlugin',
     ],
 ];
 ```

--- a/src/Heartbeat/Sensor.php
+++ b/src/Heartbeat/Sensor.php
@@ -149,13 +149,13 @@ abstract class Sensor
     abstract protected function _getStatus();
 
     /**
-     * Get the value of the given setting or an optional  fallback default value
+     * Get the value of the given setting or an optional fallback default value
      *
      * @param string $name The name of the setting to retrieve.
      * @param null|mixed $default The optional default value, if the setting is not set.
-     * @return string The value of the setting or the provided default, if not set.
+     * @return string|null The value of the setting or the provided default, if not set.
      */
-    protected function getSetting(string $name, $default = null): string
+    protected function getSetting(string $name, $default = null): ?string
     {
         $settings = $this->config->getSettings();
 

--- a/src/Heartbeat/Sensor/DBUpToDate.php
+++ b/src/Heartbeat/Sensor/DBUpToDate.php
@@ -76,7 +76,7 @@ class DBUpToDate extends Sensor
             'source' => $this->getSetting('source', $this->defaultSource),
         ];
 
-        $pluginName = $this->getSetting('plugin_name', '');
+        $pluginName = $this->getSetting('plugin', '');
         if ($pluginName !== '') {
             $options['plugin'] = $pluginName;
         }

--- a/src/Heartbeat/Sensor/DBUpToDate.php
+++ b/src/Heartbeat/Sensor/DBUpToDate.php
@@ -22,22 +22,54 @@ class DBUpToDate extends Sensor
     public const MIGRATION_STATUS_UP = 'up';
 
     /**
+     * The default connection name
+     */
+    protected string $defaultConnectionName = 'default';
+
+    /**
+     * The default migrations source (subfolder of config)
+     */
+    protected string $defaultSource = 'Migrations';
+
+    /**
      * @inheritDoc
      */
     protected function _getStatus()
     {
         $dbMigrated = true;
         try {
-            $migrations = new Migrations();
-            $status = $migrations->status();
-            $lastStatus = array_pop($status);
-            if ($lastStatus['status'] !== self::MIGRATION_STATUS_UP) {
-                $dbMigrated = false;
+            $migrations = new Migrations($this->buildMigrationsOptions());
+
+            foreach ($migrations->status() as $migration) {
+                if ($migration['status'] !== self::MIGRATION_STATUS_UP) {
+                    $dbMigrated = false;
+                    break;
+                }
             }
         } catch (\Exception $exception) {
             $dbMigrated = false;
         }
 
         return $dbMigrated;
+    }
+
+    /**
+     * Build the options array passed to the Migrations plugin.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildMigrationsOptions(): array
+    {
+        $options = [
+            'connection' => $this->getSetting('connection_name', $this->defaultConnectionName),
+            'source' => $this->getSetting('source', $this->defaultSource),
+        ];
+
+        $pluginName = $this->getSetting('plugin_name', '');
+        if ($pluginName !== '') {
+            $options['plugin'] = $pluginName;
+        }
+
+        return $options;
     }
 }

--- a/src/Heartbeat/Sensor/DBUpToDate.php
+++ b/src/Heartbeat/Sensor/DBUpToDate.php
@@ -76,8 +76,8 @@ class DBUpToDate extends Sensor
             'source' => $this->getSetting('source', $this->defaultSource),
         ];
 
-        $pluginName = $this->getSetting('plugin', '');
-        if ($pluginName !== '') {
+        $pluginName = $this->getSetting('plugin');
+        if ($pluginName !== null) {
             $options['plugin'] = $pluginName;
         }
 

--- a/src/Heartbeat/Sensor/DBUpToDate.php
+++ b/src/Heartbeat/Sensor/DBUpToDate.php
@@ -17,17 +17,17 @@ use OrcaServices\Heartbeat\Heartbeat\Sensor;
 class DBUpToDate extends Sensor
 {
     /**
-     * Migration status indicating the migration was executed successfully
+     * Migration status indicating the migration was executed successfully.
      */
     public const MIGRATION_STATUS_UP = 'up';
 
     /**
-     * The default connection name
+     * The default connection name. Defaults to `default`.
      */
     protected string $defaultConnectionName = 'default';
 
     /**
-     * The default migrations source (subfolder of config)
+     * The default migrations source (subfolder of config). Defaults to `Migrations`.
      */
     protected string $defaultSource = 'Migrations';
 

--- a/src/Heartbeat/Sensor/DBUpToDate.php
+++ b/src/Heartbeat/Sensor/DBUpToDate.php
@@ -38,7 +38,7 @@ class DBUpToDate extends Sensor
     {
         $dbMigrated = true;
         try {
-            $migrations = new Migrations($this->buildMigrationsOptions());
+            $migrations = $this->createMigrations($this->buildMigrationsOptions());
 
             foreach ($migrations->status() as $migration) {
                 if ($migration['status'] !== self::MIGRATION_STATUS_UP) {
@@ -51,6 +51,17 @@ class DBUpToDate extends Sensor
         }
 
         return $dbMigrated;
+    }
+
+    /**
+     * Creates the Migrations instance used to check the status.
+     *
+     * @param array<string, mixed> $options Options as built by buildMigrationsOptions()
+     * @return Migrations
+     */
+    protected function createMigrations(array $options): Migrations
+    {
+        return new Migrations($options);
     }
 
     /**

--- a/tests/TestCase/Heartbeat/Sensor/DBConnectionTest.php
+++ b/tests/TestCase/Heartbeat/Sensor/DBConnectionTest.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+namespace OrcaServices\Heartbeat\Test\TestCase\Heartbeat\Sensor;
+
+use Cake\Database\Connection;
+use Cake\Database\Driver\Sqlite;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+use OrcaServices\Heartbeat\Heartbeat\Sensor\Config;
+use OrcaServices\Heartbeat\Heartbeat\Sensor\DBConnection;
+
+/**
+ * DB Connection Sensor Test
+ *
+ * @coversDefaultClass DBConnection
+ */
+class DBConnectionTest extends TestCase
+{
+    /**
+     * Name of the test database connection.
+     *
+     * @var string
+     */
+    private const TEST_CONNECTION = 'heartbeat_db_connection_test';
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (!extension_loaded('pdo_sqlite')) {
+            $this->markTestSkipped('The pdo_sqlite extension is required for this test.');
+        }
+
+        ConnectionManager::setConfig(self::TEST_CONNECTION, [
+            'className' => Connection::class,
+            'driver' => Sqlite::class,
+            'database' => ':memory:',
+        ]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void
+    {
+        ConnectionManager::drop(self::TEST_CONNECTION);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Builds a configured DBConnection sensor.
+     *
+     * @param array $settings Sensor settings
+     * @return DBConnection
+     */
+    private function createSensor(array $settings = []): DBConnection
+    {
+        $config = new Config('DB Connection', [
+            'enabled' => true,
+            'severity' => 3,
+            'class' => DBConnection::class,
+            'settings' => $settings,
+        ]);
+
+        return new DBConnection($config);
+    }
+
+    /**
+     * Test _getStatus for a healthy connection.
+     *
+     * @return void
+     * @covers ::_getStatus
+     */
+    public function testGetStatusReturnsTrueForReachableConnection(): void
+    {
+        $sensor = $this->createSensor(['connection_name' => self::TEST_CONNECTION]);
+
+        $status = $sensor->getStatus();
+
+        $this->assertTrue($status->getStatus());
+    }
+
+    /**
+     * Test _getStatus for an unknown connection.
+     *
+     * @return void
+     * @covers ::_getStatus
+     */
+    public function testGetStatusReturnsFalseForUnknownConnection(): void
+    {
+        $sensor = $this->createSensor(['connection_name' => 'this_connection_does_not_exist']);
+
+        $status = $sensor->getStatus();
+
+        $this->assertFalse($status->getStatus());
+    }
+}

--- a/tests/TestCase/Heartbeat/Sensor/DBConnectionTest.php
+++ b/tests/TestCase/Heartbeat/Sensor/DBConnectionTest.php
@@ -71,12 +71,27 @@ class DBConnectionTest extends TestCase
     }
 
     /**
-     * Test _getStatus for a healthy connection.
+     * Test _getStatus for the default connection.
      *
      * @return void
      * @covers ::_getStatus
      */
-    public function testGetStatusReturnsTrueForReachableConnection(): void
+    public function testGetStatusReturnsTrueForDefaultConnection(): void
+    {
+        $sensor = $this->createSensor();
+
+        $status = $sensor->getStatus();
+
+        $this->assertTrue($status->getStatus());
+    }
+
+    /**
+     * Test _getStatus for a custom connection.
+     *
+     * @return void
+     * @covers ::_getStatus
+     */
+    public function testGetStatusReturnsTrueForCustomConnection(): void
     {
         $sensor = $this->createSensor(['connection_name' => self::TEST_CONNECTION]);
 

--- a/tests/TestCase/Heartbeat/Sensor/DBConnectionTest.php
+++ b/tests/TestCase/Heartbeat/Sensor/DBConnectionTest.php
@@ -29,11 +29,11 @@ class DBConnectionTest extends TestCase
      */
     public function setUp(): void
     {
-        parent::setUp();
-
         if (!extension_loaded('pdo_sqlite')) {
             $this->markTestSkipped('The pdo_sqlite extension is required for this test.');
         }
+
+        parent::setUp();
 
         ConnectionManager::setConfig(self::TEST_CONNECTION, [
             'className' => Connection::class,

--- a/tests/TestCase/Heartbeat/Sensor/DBUpToDateTest.php
+++ b/tests/TestCase/Heartbeat/Sensor/DBUpToDateTest.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+namespace OrcaServices\Heartbeat\Test\TestCase\Heartbeat\Sensor;
+
+use Cake\TestSuite\TestCase;
+use Migrations\Migrations;
+use OrcaServices\Heartbeat\Heartbeat\Sensor\Config;
+use OrcaServices\Heartbeat\Heartbeat\Sensor\DBUpToDate;
+use PHPUnit\Framework\MockObject\MockObject;
+use RuntimeException;
+
+/**
+ * DB Up to Date Sensor Test
+ *
+ * @coversDefaultClass DBUpToDate
+ */
+class DBUpToDateTest extends TestCase
+{
+    /**
+     * Builds a sensor with the given Migrations mock.
+     *
+     * @param Migrations|MockObject $migrations Mocked Migrations
+     * @param array<string, mixed> $settings Sensor settings
+     * @return DBUpToDate
+     */
+    private function createSensor($migrations, array $settings = []): DBUpToDate
+    {
+        $config = new Config('DB up to date', [
+            'enabled' => true,
+            'severity' => 3,
+            'class' => DBUpToDate::class,
+            'settings' => $settings,
+        ]);
+
+        return new class ($config, $migrations) extends DBUpToDate {
+            private Migrations $mockedMigrations;
+
+            public function __construct(Config $config, Migrations $mockedMigrations)
+            {
+                parent::__construct($config);
+                $this->mockedMigrations = $mockedMigrations;
+            }
+
+            protected function createMigrations(array $options): Migrations
+            {
+                return $this->mockedMigrations;
+            }
+        };
+    }
+
+    /**
+     * Creates a Migrations mock that returns the given status() result.
+     *
+     * @param array<int, array<string, mixed>> $statusResult Return value of status()
+     * @return Migrations|MockObject
+     */
+    private function createMigrationsMock(array $statusResult): MockObject
+    {
+        $migrations = $this->createMock(Migrations::class);
+        $migrations->method('status')->willReturn($statusResult);
+
+        return $migrations;
+    }
+
+    /**
+     * When every migration reports status "up", the sensor reports true.
+     *
+     * @return void
+     * @covers ::_getStatus
+     */
+    public function testGetStatusReturnsTrueWhenAllMigrationsAreUp(): void
+    {
+        $migrations = $this->createMigrationsMock([
+            ['status' => 'up', 'version' => '20200101000000'],
+            ['status' => 'up', 'version' => '20200102000000'],
+        ]);
+
+        $sensor = $this->createSensor($migrations);
+
+        $this->assertTrue($sensor->getStatus()->getStatus());
+    }
+
+    /**
+     * When at least one migration is not "up", the sensor reports false.
+     *
+     * @return void
+     * @covers ::_getStatus
+     */
+    public function testGetStatusReturnsFalseWhenAMigrationIsPending(): void
+    {
+        $migrations = $this->createMigrationsMock([
+            ['status' => 'up', 'version' => '20200101000000'],
+            ['status' => 'down', 'version' => '20200102000000'],
+        ]);
+
+        $sensor = $this->createSensor($migrations);
+
+        $this->assertFalse($sensor->getStatus()->getStatus());
+    }
+
+    /**
+     * An empty migration list (no migrations at all) is treated as up to date.
+     *
+     * @return void
+     * @covers ::_getStatus
+     */
+    public function testGetStatusReturnsTrueWhenThereAreNoMigrations(): void
+    {
+        $migrations = $this->createMigrationsMock([]);
+
+        $sensor = $this->createSensor($migrations);
+
+        $this->assertTrue($sensor->getStatus()->getStatus());
+    }
+
+    /**
+     * If Migrations::status() throws, the sensor catches it and reports false.
+     *
+     * @return void
+     * @covers ::_getStatus
+     */
+    public function testGetStatusReturnsFalseWhenStatusThrows(): void
+    {
+        $migrations = $this->createMock(Migrations::class);
+        $migrations->method('status')->willThrowException(new RuntimeException());
+
+        $sensor = $this->createSensor($migrations);
+
+        $this->assertFalse($sensor->getStatus()->getStatus());
+    }
+}

--- a/tests/TestCase/Heartbeat/Sensor/DebugModeTest.php
+++ b/tests/TestCase/Heartbeat/Sensor/DebugModeTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace OrcaServices\Heartbeat\Test\TestCase\Heartbeat\Sensor;
+
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use OrcaServices\Heartbeat\Heartbeat\Sensor\Config;
+use OrcaServices\Heartbeat\Heartbeat\Sensor\DebugMode;
+
+/**
+ * Debug Mode Sensor Test
+ *
+ * @coversDefaultClass DebugMode
+ */
+class DebugModeTest extends TestCase
+{
+    /**
+     * Builds a configured DebugMode sensor.
+     *
+     * @return DebugMode
+     */
+    private function createSensor(): DebugMode
+    {
+        $config = new Config('Debug-Mode', [
+            'enabled' => true,
+            'severity' => 1,
+            'class' => DebugMode::class,
+        ]);
+
+        return new DebugMode($config);
+    }
+
+    /**
+     * When debug mode is enabled, the sensor reports the string '1'.
+     *
+     * @return void
+     * @covers ::_getStatus
+     */
+    public function testGetStatusReturnsOneWhenDebugIsEnabled(): void
+    {
+        Configure::write('debug', true);
+
+        $sensor = $this->createSensor();
+
+        $this->assertSame('1', $sensor->getStatus()->getStatus());
+    }
+
+    /**
+     * When debug mode is disabled, the sensor reports the string '' (the (string) cast of boolean false).
+     *
+     * @return void
+     * @covers ::_getStatus
+     */
+    public function testGetStatusReturnsEmptyStringWhenDebugIsDisabled(): void
+    {
+        Configure::write('debug', false);
+
+        $sensor = $this->createSensor();
+
+        $this->assertSame('', $sensor->getStatus()->getStatus());
+    }
+}


### PR DESCRIPTION
In the issue [Make DB connection name configurable](https://github.com/orca-services/cakephp-heartbeat/issues/14), we made the connection name of the DBConnection sensor configurable.  
Unfortunately, the DBUpToDate sensor still uses only the default connection.

This issue aims to make the connection name of the DBUpToDate sensor configurable as well.

Please note that you must also specify the plugin and the source of the migrations to be executed.

Closes #40 